### PR TITLE
publish for scala 2.13.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ inThisBuild {
     licenses := Seq(Apache2),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scalatest"  %% "scalatest"    % "3.0.4"
     )
   )
 }
@@ -20,7 +21,7 @@ val common = Seq(
       s"""-Dpcplod.classpath=${(fullClasspath in Test).value.map(_.data).mkString(",")}"""
     )
   },
-  mimaPreviousArtifacts := Set(organization.value %% name.value % "1.2.1")
+  mimaPreviousArtifacts := Set(organization.value %% name.value % "1.2.2")
 )
 
 lazy val pcplod = project.settings(common)


### PR DESCRIPTION
This is more a question than a real pull request. I am trying to publish a version of pcplod for scala 2.13.0-M2 in order to publish a new version of kind-projector.

Unfortunately I don't understand where the settings for pcplod come from. They seem to come from `sbt-sensible` which is not under @fommil account anymore. Can anyone help me with this? @rorygraves maybe?

Thanks.